### PR TITLE
Added Facade for easy Flagsmith access

### DIFF
--- a/src/Facades/LaravelFlagsmith.php
+++ b/src/Facades/LaravelFlagsmith.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Clearlyip\LaravelFlagsmith\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Flagsmith\Flagsmith;
+
+class LaravelFlagsmith extends Facade {
+
+	protected static function getFacadeAccessor() {
+        return Flagsmith::class;
+    }
+}


### PR DESCRIPTION
How about adding a Facades to retrieve the Flagsmith instance?

```php
use Clearlyip\LaravelFlagsmith\Facades\LaravelFlagsmith;

// retrieve FlagSmith instance and call directly its function
LaravelFlagsmith::getFeatureValue( 'feature1' );
```