### PR TITLE
✨ Feature - Support Laravel 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
-        "laravel/framework": "^8.0 || ^9.0",
-        "flagsmith/flagsmith-php-client": "^2.0"
+        "php": ">=7.4",
+        "laravel/framework": ">=8.0",
+        "flagsmith/flagsmith-php-client": ">=2.0"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
## Description

Re-configured `composer.json` to require minimum or above:
| Dependency | version |
| --- | --- |
| `php` | 8.0 |
| `laravel/framework` | 8.0 |
| `flagsmith/flagsmith-php-client` | 2.0 |

With these changes, this package appears to work again as expected on Laravel 10.

## Tested on:
| Dependency | version |
| --- | --- |
| `php` | 8.1.17 |
| `laravel/framework` | 10.8.0 |
| `flagsmith/flagsmith-php-client` | 2.1.1 |
